### PR TITLE
Remove dependency on thepudds/swisstable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.18
 require (
 	github.com/dolthub/maphash v0.0.0-20221220182448-74e1e1ea1577
 	github.com/stretchr/testify v1.8.1
-	github.com/thepudds/swisstable v0.0.0-20221011152303-9c77dc657777
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -3,10 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dolthub/maphash v0.0.0-20221220182448-74e1e1ea1577 h1:SegEguMxToBn045KRHLIUlF2/jR7Y2qD6fF+3tdOfvI=
 github.com/dolthub/maphash v0.0.0-20221220182448-74e1e1ea1577/go.mod h1:gkg4Ch4CdCDu5h6PMriVLawB7koZ+5ijb9puGMV50a4=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/sanity-io/litter v1.5.1 h1:dwnrSypP6q56o3lFxTU+t2fwQ9A+U5qrXVO4Qg9KwVU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -14,9 +12,6 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/thepudds/fzgen v0.4.2 h1:HlEHl5hk2/cqEomf2uK5SA/FeJc12s/vIHmOG+FbACw=
-github.com/thepudds/swisstable v0.0.0-20221011152303-9c77dc657777 h1:5u+6YWU2faS+Sr/x8j9yalMpSDUkatNOZWXV3wMUCGQ=
-github.com/thepudds/swisstable v0.0.0-20221011152303-9c77dc657777/go.mod h1:4af3KxEsswy6aTzsTcwa8QZUSh4V+80oHdp1QX9uJHA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/map_bench_test.go
+++ b/map_bench_test.go
@@ -22,8 +22,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/thepudds/swisstable"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -51,9 +49,6 @@ func BenchmarkInt64Maps(b *testing.B) {
 			})
 			b.Run("swiss.Map", func(b *testing.B) {
 				benchmarkSwissMap(b, generateInt64Data(n))
-			})
-			b.Run("swisstable.Map", func(b *testing.B) {
-				benchmarkThepuddsMap(b, generateInt64Data(n))
 			})
 		})
 	}
@@ -111,24 +106,6 @@ func benchmarkSwissMap[K comparable](b *testing.B, keys []K) {
 	}
 	assert.True(b, ok)
 	b.ReportAllocs()
-}
-
-func benchmarkThepuddsMap(b *testing.B, keys []int64) {
-	n := uint32(len(keys))
-	mod := n - 1 // power of 2 fast modulus
-	require.Equal(b, 1, bits.OnesCount32(n))
-	m := swisstable.New(len(keys))
-	for _, k := range keys {
-		m.Set(swisstable.Key(k), swisstable.Value(k))
-	}
-	b.ResetTimer()
-	var v swisstable.Value
-	var ok bool
-	for i := 0; i < b.N; i++ {
-		v, ok = m.Get(swisstable.Key(keys[uint32(i)&mod]))
-	}
-	assert.NotNil(b, v)
-	assert.True(b, ok)
 }
 
 func generateInt64Data(n int) (data []int64) {


### PR DESCRIPTION
[`thepudds/swisstable`](https://github.com/thepudds/swisstable) is another hash table implementation based on SwissTable. It was added as a test dependency for comparison in microbenchmarks. However, it on builds on `amd64`, making it a pain for developers on Arm. Fixes https://github.com/dolthub/swiss/issues/6.