### PR TITLE
map.go: Change Delete and Clear so they reset the key and value for a removed entry to the zero value.

### DIFF
--- a/map.go
+++ b/map.go
@@ -185,6 +185,10 @@ func (m *Map[K, V]) Delete(key K) (ok bool) {
 					m.ctrl[g][s] = tombstone
 					m.dead++
 				}
+				var k K
+				var v V
+				m.groups[g].keys[s] = k
+				m.groups[g].values[s] = v
 				return
 			}
 		}
@@ -235,6 +239,14 @@ func (m *Map[K, V]) Clear() {
 	for i, c := range m.ctrl {
 		for j := range c {
 			m.ctrl[i][j] = empty
+		}
+	}
+	var k K
+	var v V
+	for _, g := range m.groups {
+		for i := range g.keys {
+			g.keys[i] = k
+			g.values[i] = v
 		}
 	}
 	m.resident, m.dead = 0, 0


### PR DESCRIPTION
For value types, leaving the values in place while clearing the metadata is correct and the most efficient thing to do. But for anything that holds a pointer or a slice, it leaks the referenced memory until the map itself is collected or the hash slot entry happens to get replaced by a later entry.

This is an unacceptable lifecycle violation for general use cases.